### PR TITLE
Flash minting

### DIFF
--- a/contracts/FlashMinter.sol
+++ b/contracts/FlashMinter.sol
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.7.0;
+pragma solidity 0.7.0;
 
-
-interface FlashMintableLike {
-    function flashMint(uint256, bytes calldata) external;
-}
-
-interface ERC20BalanceLike {
+interface FlashMinterLike {
     function balanceOf(address) external returns (uint256);
+    function executeOnFlashMint(uint256 value, bytes calldata data) external;
+    function flashMint(uint256, bytes calldata) external;
 }
 
 contract FlashMinter {
@@ -19,11 +16,11 @@ contract FlashMinter {
         flashValue = value;
         (address target) = abi.decode(data, (address)); // Use this to unpack arbitrary data
         flashData = target;
-        flashBalance = ERC20BalanceLike(target).balanceOf(address(this));
+        flashBalance = FlashMinterLike(target).balanceOf(address(this));
     }
 
-    function flashMint(address target, address user, uint256 value) external {
+    function flashMint(address target, uint256 value) external {
         bytes memory data = abi.encode(target); // Use this to pack arbitrary data to `executeOnFlashMint`
-        FlashMintableLike(target).flashMint(value, data);
+        FlashMinterLike(target).flashMint(value, data);
     }
 }

--- a/contracts/FlashMinter.sol
+++ b/contracts/FlashMinter.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.7.0;
+
+
+interface FlashMintableLike {
+    function flashMint(uint256, bytes calldata) external;
+}
+
+interface ERC20BalanceLike {
+    function balanceOf(address) external returns (uint256);
+}
+
+contract FlashMinter {
+    uint256 public flashBalance;
+    uint256 public flashValue;
+    address public flashData;
+
+    function executeOnFlashMint(uint256 value, bytes calldata data) external {
+        flashValue = value;
+        (address target) = abi.decode(data, (address)); // Use this to unpack arbitrary data
+        flashData = target;
+        flashBalance = ERC20BalanceLike(target).balanceOf(address(this));
+    }
+
+    function flashMint(address target, address user, uint256 value) external {
+        bytes memory data = abi.encode(target); // Use this to pack arbitrary data to `executeOnFlashMint`
+        FlashMintableLike(target).flashMint(value, data);
+    }
+}

--- a/contracts/WETH10.sol
+++ b/contracts/WETH10.sol
@@ -1,7 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.7.0;
 // Copyright (C) 2015, 2016, 2017 Dapphub // Adapted by Ethereum Community 2020
-
 
 contract WETH10 {
     string public constant name = "Wrapped Ether";
@@ -17,7 +15,7 @@ contract WETH10 {
     mapping (address => uint256)                       public  nonces;
     mapping (address => mapping (address => uint256))  public  allowance;
 
-    uint public unlocked = 1;
+    uint256 private unlocked = 1;
 
     constructor() {
         uint256 chainId;
@@ -32,7 +30,7 @@ contract WETH10 {
     }
 
     modifier lock() {
-        require(unlocked == 1, 'locked');
+        require(unlocked == 1, "locked");
         unlocked = 0;
         _;
         unlocked = 1;
@@ -167,8 +165,4 @@ contract WETH10 {
         balanceOf[msg.sender] -= value;
         emit Transfer(msg.sender, address(0), value);
     }
-}
-
-interface FlashMinterLike {
-    function executeOnFlashMint(uint256 value, bytes calldata data) external;
 }

--- a/test/01_WETH10.test.js
+++ b/test/01_WETH10.test.js
@@ -4,7 +4,7 @@ const { signERC2612Permit } = require('eth-permit');
 const { BN, expectRevert } = require('@openzeppelin/test-helpers')
 require('chai').use(require('chai-as-promised')).should()
 
-contract('TestOracle', (accounts) => {
+contract('WETH10', (accounts) => {
   const [deployer, user1, user2] = accounts
   let weth
 

--- a/test/02_WETH10_Flash.test.js
+++ b/test/02_WETH10_Flash.test.js
@@ -1,0 +1,29 @@
+const WETH10 = artifacts.require('WETH10')
+const FlashMinter = artifacts.require('FlashMinter')
+
+const { BN } = require('@openzeppelin/test-helpers')
+require('chai').use(require('chai-as-promised')).should()
+
+contract('WETH10 - Flash Minting', (accounts) => {
+  const [deployer, user1, user2] = accounts
+  let weth
+  let flash
+
+  beforeEach(async () => {
+    weth = await WETH10.new({ from: deployer })
+    flash = await FlashMinter.new({ from: deployer })
+  })
+
+  it('flash mints', async () => {
+    flash.flashMint(weth.address, deployer, 1, { from: deployer })
+
+    const balanceAfter = await weth.balanceOf(deployer)
+    balanceAfter.toString().should.equal((new BN('0')).toString())
+    const flashBalance = await flash.flashBalance()
+    flashBalance.toString().should.equal((new BN('1')).toString())
+    const flashValue = await flash.flashValue()
+    flashValue.toString().should.equal((new BN('1')).toString())
+    const flashData = await flash.flashData()
+    flashData.toString().should.equal(weth.address)
+  })
+})


### PR DESCRIPTION
Flash mint and burn to msg.sender.
Arbitrary data can be passed on a `bytes calldata` parameter.
`deposit` and `withdraw` methods locked for flash minting, too much potential for abuse.
Overflow checks in non-locked methods.

Fixes #16 