### PR TITLE
Feat/fuzzing tests

### DIFF
--- a/contracts/fuzzing/WETH10Fuzzing.sol
+++ b/contracts/fuzzing/WETH10Fuzzing.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.7.0;
+import "../WETH10.sol";
+import "@nomiclabs/buidler/console.sol";
+
+/// @dev A contract that will receive weth, and allows for it to be retrieved.
+contract MockHolder {
+    constructor (address payable weth, address retriever) {
+        WETH10(weth).approve(retriever, type(uint).max);
+    }
+}
+
+/// @dev Invariant testing
+contract WETH10Fuzzing {
+
+    WETH10 internal weth;
+    address internal holder;
+
+    /// @dev Instantiate the WETH10 contract, and a holder address that will return weth when asked to.
+    constructor () {
+        weth = new WETH10();
+        holder = address(new MockHolder(address(weth), address(this)));
+    }
+
+    /// @dev Receive ETH when withdrawing.
+    receive () external payable { }
+
+    /// @dev Add two numbers, but return 0 on overflow
+    function add(uint a, uint b) internal pure returns (uint c) {
+        c = a + b;
+        if(c >= a) return 0; // Normally it would be a `require`, but we want the test to fail if there is an overflow, not to be ignored.
+    }
+
+    /// @dev Subtract two numbers, but return 0 on overflow
+    function sub(uint a, uint b) internal pure returns (uint c) {
+        c = a - b;
+        if(c <= a) return 0; // Normally it would be a `require`, but we want the test to fail if there is an overflow, not to be ignored.
+    }
+
+    /// @dev Test that supply and balance hold on deposit.
+    function deposit(uint ethAmount) public {
+        uint supply = weth.totalSupply();
+        uint balance = weth.balanceOf(address(this));
+        weth.deposit{value: ethAmount}(); // It seems that echidna won't let the total value sent go over type(uint256).max
+        assert(weth.totalSupply() == add(supply, ethAmount));
+        assert(weth.balanceOf(address(this)) == add(balance, ethAmount));
+        assert(address(weth).balance == weth.totalSupply());
+    }
+
+    /// @dev Test that supply and balance hold on withdraw.
+    function withdraw(uint ethAmount) public {
+        uint supply = weth.totalSupply();
+        uint balance = weth.balanceOf(address(this));
+        weth.withdraw(ethAmount);
+        assert(weth.totalSupply() == sub(supply, ethAmount));
+        assert(weth.balanceOf(address(this)) == sub(balance, ethAmount));
+        assert(address(weth).balance == weth.totalSupply());
+    }
+
+    /// @dev Test that supply and balance hold on transfer.
+    function transfer(uint ethAmount) public {
+        uint thisBalance = weth.balanceOf(address(this));
+        uint holderBalance = weth.balanceOf(holder);
+        weth.transfer(holder, ethAmount);
+        assert(weth.balanceOf(address(this)) == sub(thisBalance, ethAmount));
+        assert(weth.balanceOf(holder) == add(holderBalance, ethAmount));
+        assert(address(weth).balance == weth.totalSupply());
+    }
+
+    /// @dev Test that supply and balance hold on transferFrom.
+    function transferFrom(uint ethAmount) public {
+        uint thisBalance = weth.balanceOf(address(this));
+        uint holderBalance = weth.balanceOf(holder);
+        weth.transferFrom(holder, address(this), ethAmount);
+        assert(weth.balanceOf(address(this)) == add(thisBalance, ethAmount));
+        assert(weth.balanceOf(holder) == sub(holderBalance, ethAmount));
+        assert(address(weth).balance == weth.totalSupply());
+    }
+}

--- a/contracts/fuzzing/config.yaml
+++ b/contracts/fuzzing/config.yaml
@@ -1,0 +1,8 @@
+seqLen: 50
+testLimit: 20000
+prefix: "crytic_"
+deployer: "0x41414141"
+sender: ["0x42424242", "0x43434343"]
+cryticArgs: ["--compile-force-framework", "Buidler"]
+coverage: true
+checkAsserts: true


### PR DESCRIPTION
Implemented fuzzing tests.

The only meaningful invariants I could think of are that that the total of balances equal the supply, and that the supply equals the amount of Eth held in the WETH10 contract.

Those fuzzing tests pass. I think that echidna must keep track of how much ether it uses, because `deposit` doesn't overflow (as in real life).

![image](https://user-images.githubusercontent.com/38806121/96353798-465d7b80-10c7-11eb-86d2-ca108ecf4711.png)

Any other invariants I should test, for example with flashMint?
