### PR TITLE
Prevent transfer to token contract: simple

### DIFF
--- a/contracts/WETH10.sol
+++ b/contracts/WETH10.sol
@@ -57,6 +57,7 @@ contract WETH10 {
     }
     
     function depositTo(address to) external payable lock {
+        require(to != address(this), '!contract');
         balanceOf[to] += msg.value;
         emit Transfer(address(0), to, msg.value);
     }
@@ -72,6 +73,7 @@ contract WETH10 {
     }
     
     function withdrawTo(address to, uint256 value) external lock {
+        require(to != address(this), '!contract');
         require(balanceOf[msg.sender] >= value, "!balance");
         
         balanceOf[msg.sender] -= value;
@@ -82,6 +84,7 @@ contract WETH10 {
     }
     
     function withdrawFrom(address from, address to, uint256 value) external lock {
+        require(to != address(this), '!contract');
         require(balanceOf[from] >= value, "!balance");
 
         
@@ -147,6 +150,7 @@ contract WETH10 {
     }
     
     function transfer(address to, uint256 value) external returns (bool) {
+        require(to != address(this), '!contract');
         require(balanceOf[msg.sender] >= value, "!balance");
         require(balanceOf[to] + value >= value, "overflow");
 
@@ -159,6 +163,7 @@ contract WETH10 {
     }
     
     function transferFrom(address from, address to, uint256 value) public returns (bool) {
+        require(to != address(this), '!contract');
         require(balanceOf[from] >= value, "!balance");
         require(balanceOf[to] + value >= value, "overflow");
 

--- a/test/01_WETH10.test.js
+++ b/test/01_WETH10.test.js
@@ -65,6 +65,10 @@ contract('WETH10', (accounts) => {
         events[0].returnValues.data.should.equal('0x11')
       });
 
+      it('should not transfer to the contract address', async () => {
+        await expectRevert(weth.transfer(weth.address, 1, { from: user1 }), '!contract');
+      });
+
       it('approves to increase allowance', async () => {
         const allowanceBefore = await weth.allowance(user1, user2)
         await weth.approve(user2, 1, { from: user1 })


### PR DESCRIPTION
See #37 

This implementation adds simple require calls to prevent transfers of ETH or WETH to the token contract.